### PR TITLE
Mobile improvements

### DIFF
--- a/lib/hanna-nouveau/template_files/layout.erb
+++ b/lib/hanna-nouveau/template_files/layout.erb
@@ -2,6 +2,7 @@
 <html lang='en'>
 <head>
 <title><%= h(values[:title]) if values[:title] %></title>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
 <meta content='text/html; charset=<%=h @options.charset %>' http-equiv='Content-Type'>
 <link href='<%=h values[:stylesheet] %>' media='screen' rel='stylesheet' type='text/css'>
 <% if index %><base target='docwin'>

--- a/lib/hanna-nouveau/template_files/styles.css
+++ b/lib/hanna-nouveau/template_files/styles.css
@@ -245,7 +245,10 @@ div.header {
       white-space: normal; }
   #content table.rdoc-list {
     border-collapse: collapse;
-    border-spacing: 0; }
+    border-spacing: 0;
+    width: 100%;
+    overflow: auto;
+    display: block; }
     #content table.rdoc-list tr {
       background-color: white; }
       #content table.rdoc-list tr:nth-child(2n) {

--- a/lib/hanna-nouveau/template_files/styles.css
+++ b/lib/hanna-nouveau/template_files/styles.css
@@ -164,7 +164,7 @@ table {
 
 div.header {
   font-size: 80%;
-  padding: 0.5em 2%;
+  padding: 0.5em 1rem;
   font-family: Arial, Helvetica, sans-serif;
   border-bottom: 1px solid silver; }
   div.header .name {
@@ -187,7 +187,7 @@ div.header {
       color: #484848; }
 
 #content {
-  padding: 12px 2%; }
+  padding: 12px 1rem; }
   div.class #content {
     position: relative;
     width: 72%; }


### PR DESCRIPTION
Whenever I was reading documentation generated by this renderer on a mobile device, I always found it too small to read comfortably. So, I wanted to find an easy way to improve this.

https://user-images.githubusercontent.com/795488/197769619-e97f1fdd-7394-42bd-ae0e-09d12783d6e4.mp4

This PR adds a standard viewport `<meta>` tag, which makes the font size on mobile devices ideal for me. This change caused tables to overflow, making the whole page horizontally scrollable, so we ensure that overflowing tables are individually scrollable. I also increased overall horizontal padding a little bit, so that it's more comfortable on mobile devices.

https://user-images.githubusercontent.com/795488/197769744-74886494-3455-455b-9e20-719886ed644f.mp4