### PR TITLE
More mobile improvements

### DIFF
--- a/lib/hanna-nouveau/template_files/styles.css
+++ b/lib/hanna-nouveau/template_files/styles.css
@@ -169,7 +169,8 @@ div.header {
   border-bottom: 1px solid silver; }
   div.header .name {
     font-size: 1.6em;
-    font-family: Georgia, serif; }
+    font-family: Georgia, serif;
+    overflow-wrap: break-word; }
     div.header .name .type {
       color: #666666;
       font-size: 80%;
@@ -188,11 +189,9 @@ div.header {
 
 #content {
   padding: 12px 1rem; }
-  div.class #content {
-    position: relative;
-    width: 72%; }
   #content pre, #content .method .synopsis {
-    font: 14px Monaco, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace; }
+    font: 14px Monaco, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
+    overflow-wrap: break-word; }
   #content pre {
     color: black;
     background: #eeeeee;
@@ -260,14 +259,12 @@ div.header {
       padding: 6px 13px; }
 
 #method-list {
-  position: absolute;
-  top: 0px;
-  right: -33%;
-  width: 28%;
+  max-height: 30rem;
   background: #eeeeee;
   border: 1px solid silver;
   padding: 0.4em 1%;
-  overflow: hidden; }
+  overflow-y: auto;
+  overflow-x: hidden; }
   #method-list h2 {
     font-size: 1.3em; }
   #method-list h3 {
@@ -288,6 +285,9 @@ div.header {
   font: small-caps 1.2em Georgia, serif;
   color: #444444;
   margin: 1em 0 0.2em 0; }
+
+.name-list, #class-list ol, #context ol {
+  overflow: auto; }
 
 #methods .method {
   border: 1px solid silver;
@@ -319,7 +319,6 @@ div.header {
 #content .method .source pre, #content pre.ruby, #methods .method .description pre.ruby {
   background: #262626;
   color: #ffdead;
-  margin: 1em;
   padding: 0.5em;
   border: 1px dashed #999999;
   overflow: auto; }
@@ -354,3 +353,16 @@ div.header {
   #content .method .source pre .ruby-value, #content pre.ruby .ruby-value, #methods .method .description pre.ruby .ruby-value {
     color: #7fffd4;
     background: transparent; }
+
+@media (min-width: 640px) {
+  div.class #content {
+    position: relative;
+    width: 72%; }
+
+  #method-list {
+    position: absolute;
+    top: 0px;
+    right: -33%;
+    width: 28%;
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/jeremyevans/hanna-nouveau/pull/18, and should solve most cases of overflowing text causing full-page horizontal scroll.

I added word break to the header, to prevent overflow that makes the whole page horizontally scrollable on mobile.

https://user-images.githubusercontent.com/795488/210663509-bbd23ae9-1cc5-47d4-a2fe-2759c53efaf7.mov

The method list is now displayed within normal flow of the document on mobile, as there is not enough horizontal place to display the method list comfortably (it's too narrow, and lot of overflowing text is hidden). The additional horizontal space for the main content is especially useful for plugin classes that only have a few of uninteresting methods.

https://user-images.githubusercontent.com/795488/210663940-da2933da-796a-4c5a-bebe-ae78db6c605f.mov

Added horizontal scrolling to various sections whose content would otherwise overflow and cause the whole page to be horizontally scrollable.

https://user-images.githubusercontent.com/795488/210664172-97b65759-7c1b-4114-aba1-7bf4a3736913.mov

Removed the horizontal margin for code blocks, to be able to display more characters. On mobile it looks crammed when code blocks are indented, because there is little horizontal space as it is.

https://user-images.githubusercontent.com/795488/210664389-fd978218-757b-47ec-8fe3-15be83b1a7eb.mov